### PR TITLE
Catch import error while `-r` (restore option)

### DIFF
--- a/couchdb-backup.sh
+++ b/couchdb-backup.sh
@@ -138,7 +138,6 @@ elif [ $backup = false ]&&[ $restore = false ]; then
     echo "... ERROR: Missing argument '-b' (Backup), or '-r' (Restore)"
     usage
 fi
-
 # Handle empty args
 # url
 if [ "x$url" = "x" ]; then
@@ -507,7 +506,7 @@ elif [ $restore = true ]&&[ $backup = false ]; then
         until [ $A = 1 ]; do
             (( attemptcount++ ))
             curl -T $file_name -X POST "$url/$db_name/_bulk_docs" -H 'Content-Type: application/json' -o tmp.out
-            if [ "$?" = "0" ]; then
+            if [ "`head -n 1 tmp.out | grep -c 'error'`" -eq 0 ]; then
                 echo "... INFO: Imported ${file_name_orig} Successfully."
                 rm -f tmp.out
                 rm -f ${file_name_orig}-design


### PR DESCRIPTION
Closes: #50

"Document conflict error" returns with the exit code of 0,
whereas the actual update was not properly performed.
This commit fixes this issue.

Example error output from tmp.out:
[{"id":"867e9786f36cd91754ff67c6d00fe14e","error":"conflict",
"reason":"Documentupdate conflict."}]
