### PR TITLE
Fixes for #48, #46 and #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It works on LINUX/UNIX, Bash based systems (MacOSx)
 
 **Bash command line script to EASILY Backup & Restore a CouchDB database**
 
- * Needs bash
+ * Needs bash (plus curl, tr, file, split, awk, sed)
  * Dumped database is output to a file (configurable).
 
 ##Quickstart (& quickend)
@@ -23,6 +23,10 @@ Surprisingly, there is not a straightforward way to dump a CouchDB database. Oft
 **But, using the `_all_docs` directive provides you with JSON which cannot be directly re-import back into CouchDB**.
 
 Hence, the goal of this script(s) is to give you a simple way to Dump & Restore your CouchDB database.
+
+## NOTE
+
+Attachments in Database documents are only supported in CouchDB 1.6+
 
 ## Usage
 ```
@@ -60,5 +64,5 @@ CouchDB is an append-only database. When you delete records, the metadata is mai
 With the above points in mind; the export and import does not include Deleted documents, or old revisions; therefore, using this script, you can export and re-import your data, cleansing it of any previously (logically) deleted data!
 
 If you pair this with deletion and re-creation of replication rules (using the 'update_seq' parameter to avoid re-pulling the entire DB/deleted documents from a remote node) you can manually compress and clean out an entire cluster of waste, node-by-node.
-Note though; after creating all the rules with a fixed update_seq, once completed to the entire cluster, you will need to destroy and recereate all replication rules without the fixed update_seq - else, when restarting a node etc, replication will restart from the old seq.
+Note though; after creating all the rules with a fixed update_seq, once completed to the entire cluster, you will need to destroy and recreate all replication rules without the fixed update_seq - else, when restarting a node etc, replication will restart from the old seq.
 

--- a/couchdb-backup.sh
+++ b/couchdb-backup.sh
@@ -22,7 +22,7 @@
 
 
 ###################### CODE STARTS HERE ###################
-scriptversionnumber="1.1.4"
+scriptversionnumber="1.1.5"
 
 ##START: FUNCTIONS
 usage(){
@@ -121,8 +121,8 @@ while getopts ":h?H:d:f:u:p:P:l:t:a:c?q?z?T?V?b?B?r?R?" opt; do
         H) url="$OPTARG" ;;
         d) db_name="$OPTARG" ;;
         f) file_name="$OPTARG" ;;
-        u) username="$OPTARG";;
-        p) password="$OPTARG";;
+        u) username="${OPTARG}";;
+        p) password="${OPTARG}";;
         P) port="${OPTARG}";;
         l) lines="${OPTARG}" ;;
         t) threads="${OPTARG}" ;;
@@ -244,13 +244,13 @@ fi
 
 ## Manage the addition of user+pass if needed:
 # Ensure, if one is set, both are set.
-if [ ! "x$username" = "x" ]; then
-    if [ "x$password" = "x" ]; then
+if [ ! "x${username}" = "x" ]; then
+    if [ "x${password}" = "x" ]; then
         echo "... ERROR: Password cannot be blank, if username is specified."
         usage
     fi
-elif [ ! "x$password" = "x" ]; then
-    if [ "x$username" = "x" ]; then
+elif [ ! "x${password}" = "x" ]; then
+    if [ "x${username}" = "x" ]; then
         echo "... ERROR: Username cannot be blank, if password is specified."
         usage
     fi
@@ -268,15 +268,15 @@ if [ "`echo $url | grep -ic "^https://"`" = "1" ]; then
 	curlopt="-k"
 fi
 
-if [ ! "x$username" = "x" ]&&[ ! "x$password" = "x" ]; then
+if [ ! "x${username}" = "x" ]&&[ ! "x${password}" = "x" ]; then
     curlopt="${curlopt} -u ${username}:${password}"
 fi
 
 ## Check for curl
-if [ "x`which curl`" = "x" ]; then
-    echo "... ERROR: This script requires 'curl' to be present."
-    exit 1
-fi
+curl --version >/dev/null 2>&1 || ( echo "... ERROR: This script requires 'curl' to be present."; exit 1 )
+
+# Check for tr
+tr --help >/dev/null 2>&1 || ( echo "... ERROR: This script requires 'tr' to be present."; exit 1 )
 
 ### If user selected BACKUP, run the following code:
 if [ $backup = true ]&&[ $restore = false ]; then
@@ -321,8 +321,8 @@ if [ $backup = true ]&&[ $restore = false ]; then
 
     # CouchDB has a tendancy to output Windows carridge returns in it's output -
     # This messes up us trying to sed things at the end of lines!
-    if [ "`file $file_name | grep -c CRLF`" = "1" ]; then
-        $echoVerbose && echo "... INFO: File contains Windows carridge returns- converting..."
+    if [ "`file $file_name 2>/dev/null | grep -c CRLF`" = "1" ]||[ ! "`file --help >/dev/null 2>&1; echo $?`" = "0" ]; then
+        $echoVerbose && echo "... INFO: File may contain Windows carridge returns- converting..."
         filesize=$(du -P -k ${file_name} | awk '{print$1}')
         checkdiskspace "${file_name}" $filesize
         tr -d '\r' < ${file_name} > ${file_name}.tmp


### PR DESCRIPTION
For #48  -
* Remove the need for ```which``` to be present to check for curl.

For #46 -
* Added small note to the Readme to say that attachments in documents are only supported in Couch 1.6+ (Not sure there's much point investing effort past that).

For #30 -
* Added an alternate check for missing ```file``` command, which, if missing, will trigger the CRLF processing anyway.

Also:
* Wrapped username and password variables in curly braces. Should probably follow best practise and swap all variable uses for this format at some point.