### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It works on LINUX/UNIX, Bash based systems (MacOSx)
  * Needs bash (plus curl, tr, file, split, awk, sed)
  * Dumped database is output to a file (configurable).
 
-##Quickstart (& quickend)
+## Quickstart (& quickend)
 * Backup:
 
 ```bash couchdb-backup.sh -b -H 127.0.0.1 -d my-db -f dumpedDB.json -u admin -p password```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
